### PR TITLE
initialize example with __name__

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Import and initialize your application.
 
     from flask.ext.api import FlaskAPI
 
-    app = FlaskAPI(__main__)
+    app = FlaskAPI(__name__)
 
 ## Responses
 


### PR DESCRIPTION
**main** is undefined. Presumably one would want to initialize with **name** or '**main**'. Unsure of the original intention, though.
