### PR TITLE
Support Python-Markdown 3.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Requirements:
 
 The following packages are optional:
 
-* Markdown (`2.1.0+, <3.0`): Markdown support for the browsable API
+* Markdown (`2.6+`): Markdown support for the browsable API
 
 Install using `pip`:
 

--- a/flask_api/compat.py
+++ b/flask_api/compat.py
@@ -5,6 +5,7 @@ from flask import __version__ as flask_version
 # Markdown is optional
 try:
     import markdown
+    from markdown.extensions.toc import TocExtension
 
     def apply_markdown(text):
         """
@@ -12,7 +13,7 @@ try:
         of '#' style headers to <h2>.
         """
 
-        extensions = ['headerid(level=2)']
+        extensions = [TocExtension(baselevel=2)]
         md = markdown.Markdown(extensions=extensions)
         return md.convert(text)
 


### PR DESCRIPTION
Instead of the `headerid` extension, which was [deprecated](https://python-markdown.github.io/change_log/release-2.6/#headerid-extension-pending-deprecation) in 2.6 and [raises an error](https://python-markdown.github.io/change_log/release-3.0/#headerid-extension-deprecated) in 3.0, the equivalent [`toc`](https://python-markdown.github.io/extensions/toc/) extension is used.

Instead of specifying extension parameters in `extensions` keyword, which was also [deprecated](https://python-markdown.github.io/change_log/release-2.6/#extension-configuration-as-part-of-extension-name-deprecated) in 2.6 and [raises an error](https://python-markdown.github.io/change_log/release-3.0/#extension-configuration-as-part-of-extension-name-deprecated) in 3.0, the extension instance is passed, which is the [preferred method](https://python-markdown.github.io/reference/#extensions).

The minimal supported version is now 2.6, released in [February 2015](https://python-markdown.github.io/change_log/).

Fixes #94.