### PR TITLE
modified json.dumps parameters in renderers.py and set Access-Control…

### DIFF
--- a/flask_api/renderers.py
+++ b/flask_api/renderers.py
@@ -57,7 +57,7 @@ class JSONRenderer(BaseRenderer):
             indent = None
         # Indent may be set explicitly, eg when rendered by the browsable API.
         indent = options.get('indent', indent)
-        return json.dumps(data, cls=current_app.json_encoder, ensure_ascii=False, indent=indent)
+        return json.dumps(data, cls=current_app.json_encoder, ensure_ascii=True, indent=indent, default=str)
 
 
 class HTMLRenderer(object):

--- a/flask_api/response.py
+++ b/flask_api/response.py
@@ -31,6 +31,7 @@ class APIResponse(Response):
 
         if media_type is not None:
             self.headers['Content-Type'] = str(media_type)
+        self.headers['Access-Control-Allow-Origin'] = '*'
 
     def get_renderer_options(self):
         return {


### PR DESCRIPTION
While calling  json.dumps  in renderers.py, I have changed 'ensure_ascii' to True and started passing 'default' parameter with value str. Apart from this I have set Access-Control-Allow-Origin to * in response.py, which is generally required in APIs.