### PR TITLE
docs: Fix a few typos

### DIFF
--- a/flask_api/request.py
+++ b/flask_api/request.py
@@ -137,10 +137,10 @@ class APIRequest(Request):
         Perform method and content type overloading.
 
         Provides support for browser PUT, PATCH, DELETE & other requests,
-        by specifing a '_method' form field.
+        by specifying a '_method' form field.
 
         Also provides support for browser non-form requests (eg JSON),
-        by specifing '_content' and '_content_type' form fields.
+        by specifying '_content' and '_content_type' form fields.
         """
         if not hasattr(self, '_method'):
             self.method = super().method

--- a/flask_api/tests/__init__.py
+++ b/flask_api/tests/__init__.py
@@ -1,7 +1,7 @@
 # This is a fudge that allows us to easily specify test modules.
 # For example:
 # ./runtests test_parsers
-# ./runtests test_rendereres.RendererTests.test_render_json
+# ./runtests test_renderers.RendererTests.test_render_json
 import os
 
 modules = [filename.rsplit('.', 1)[0]


### PR DESCRIPTION
There are small typos in:
- flask_api/request.py
- flask_api/tests/__init__.py

Fixes:
- Should read `specifying` rather than `specifing`.
- Should read `renderers` rather than `rendereres`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md