### PR TITLE
Update for compatibility with flask v2.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - RANDOM_SEED=0
   matrix:
-    - FLASK_VERSION=2.0.1
+    - FLASK_VERSION=2.3.2
 
 before_install:
   - pip install pipenv

--- a/flask_api/renderers.py
+++ b/flask_api/renderers.py
@@ -60,8 +60,8 @@ class JSONRenderer(BaseRenderer):
             indent = None
         # Indent may be set explicitly, eg when rendered by the browsable API.
         indent = options.get("indent", indent)
-        return json.dumps(
-            data, cls=current_app.json_encoder, ensure_ascii=False, indent=indent
+        return current_app.json.dumps(
+            data, ensure_ascii=False, indent=indent
         )
 
 

--- a/flask_api/renderers.py
+++ b/flask_api/renderers.py
@@ -1,4 +1,3 @@
-import json
 import pydoc
 import re
 

--- a/flask_api/tests/test_renderers.py
+++ b/flask_api/tests/test_renderers.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from flask.json import JSONEncoder
+from flask.json.provider import DefaultJSONProvider
 
 from flask_api import FlaskAPI, renderers, status
 from flask_api.decorators import set_renderers
@@ -39,14 +39,14 @@ class RendererTests(unittest.TestCase):
         self.assertEqual(content, expected)
 
     def test_render_json_with_custom_encoder(self):
-        class CustomJsonEncoder(JSONEncoder):
+        class CustomJsonProvider(DefaultJSONProvider):
             def default(self, o):
                 if isinstance(o, datetime):
                     return o.isoformat()
                 return super().default(o)
 
         app = self._make_app()
-        app.json_encoder = CustomJsonEncoder
+        app.json = CustomJsonProvider(app)
         renderer = renderers.JSONRenderer()
         date = datetime(2017, 10, 5, 15, 22)
         with app.app_context():


### PR DESCRIPTION
In version 2.3.0 of flask, the JSONEncoder class was removed and the app.json_encoder attribute was [removed](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0). The result that a run of the tests using flask==2.3.0 would fail. This change updates the use of flask's json mechanisms to be in line with the new standard, and similarly updates the tests to utilize those mechanisms correctly.

From other pull requests I wasn't able to tell whether there is still a Travis project that is watching this repository, but if there is and if I've understood the setup correctly, the tests should validate that this change causes the tests to pass with flask 2.3.2

Closes #151 