### PR TITLE
Promote to version 3.2

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 3.2
+
+- Fixed support for Flask `3.0`
+
 ## Version 3.1
 
 - Fixed support for Flask `2.3`.

--- a/flask_api/__init__.py
+++ b/flask_api/__init__.py
@@ -1,3 +1,3 @@
 from flask_api.app import FlaskAPI
 
-__version__ = "3.1"
+__version__ = "3.2"


### PR DESCRIPTION
Hi there, it's me again.

I see that there are already commits on the `develop` branch to support Flask 3.0+ but there has not been a release
published to PyPI. From what I saw last time, updating the version string  and the release notes seemed to be 
part of the process, so this PR is the beginning of a request to get this new version out and published so that
users (selfishly: my work) can move forward on Flask versions.

Thanks!