### PR TITLE
fix: guard url_rule None in BrowsableAPIRenderer for error handlers

### DIFF
--- a/flask_api/renderers.py
+++ b/flask_api/renderers.py
@@ -105,9 +105,18 @@ class BrowsableAPIRenderer(BaseRenderer):
         adapter = ctx.url_adapter
         allowed_methods = adapter.allowed_methods()
 
-        endpoint = request.url_rule.endpoint
-        view_name = str(endpoint)
-        view_description = current_app.view_functions[endpoint].__doc__
+        # request.url_rule may be None when the renderer is invoked from an
+        # error handler (e.g. a custom 404 handler).  Guard against that so
+        # we don't raise an AttributeError.
+        if request.url_rule is not None:
+            endpoint = request.url_rule.endpoint
+            view_name = str(endpoint)
+            view_description = current_app.view_functions[endpoint].__doc__
+        else:
+            endpoint = None
+            view_name = ""
+            view_description = None
+
         if view_description:
             if apply_markdown:
                 view_description = dedent(view_description)

--- a/flask_api/tests/test_renderers.py
+++ b/flask_api/tests/test_renderers.py
@@ -102,6 +102,32 @@ class RendererTests(unittest.TestCase):
             self.assertTrue("<h1>Happiness</h1>" in html)
             self.assertTrue("/_happiness" in html)
 
+    def test_render_browsable_from_error_handler(self):
+        """BrowsableAPIRenderer must not crash when request.url_rule is None.
+
+        This happens when the renderer is called from a custom error handler
+        (e.g. a 404 handler) where Flask hasn't matched any URL rule.
+        Regression test for https://github.com/flask-api/flask-api/issues/40.
+        """
+        app = FlaskAPI(__name__)
+
+        @app.route("/_base", methods=["GET"])
+        def base():
+            return {}
+
+        @app.errorhandler(404)
+        def not_found(error):
+            return {"detail": "Not found."}, status.HTTP_404_NOT_FOUND
+
+        with app.test_client() as client:
+            response = client.get(
+                "/_nonexistent", headers={"Accept": "text/html"}
+            )
+            self.assertEqual(response.status_code, 404)
+            html = str(response.get_data())
+            # Should render the browsable API without raising AttributeError
+            self.assertIn("Not found", html)
+
     def test_renderer_negotiation_not_implemented(self):
         renderer = renderers.BaseRenderer()
         with self.assertRaises(NotImplementedError) as context:


### PR DESCRIPTION
## Summary

Fixes #40

## Problem

When BrowsableAPIRenderer.render() is called from a custom Flask error handler (e.g. a 404 handler), equest.url_rule is None because Flask hasn't matched any URL rule. Line 108 in enderers.py was accessing equest.url_rule.endpoint unconditionally, raising:

\\\
AttributeError: 'NoneType' object has no attribute 'endpoint'
\\\

**Minimal repro:**
\\\python
from flask_api import FlaskAPI

app = FlaskAPI(__name__)

@app.errorhandler(404)
def not_found(error):
    return {}  # crashes in BrowsableAPIRenderer

app.run(debug=True)
\\\
As documented in [Flask's API docs](https://flask.palletsprojects.com/en/stable/api/#flask.Request.url_rule), url_rule may be None when no URL rule matched.

## Fix

Guard the endpoint, iew_name, and iew_description lookups with a None check. When url_rule is None, iew_name defaults to an empty string and iew_description to None, so the browsable API renders without a title/description — which is the correct behavior for error responses.

## Tests

Added 	est_render_browsable_from_error_handler to 	est_renderers.py which registers a custom 404 handler and verifies the browsable renderer no longer raises AttributeError.